### PR TITLE
Remove incomplete function prototype.

### DIFF
--- a/ctm_rmail/options.h
+++ b/ctm_rmail/options.h
@@ -54,7 +54,6 @@
 
 static char *O_usage;
 static char *O_name;
-extern long atol();
 
 void
 pusage()


### PR DESCRIPTION
The proper prototype is present in <stdlib.h>.